### PR TITLE
make compatible with japaric's RTFM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,7 @@ extern crate cortex_m_rt;
 pub use cortex_m::*;
 pub use cortex_m_rt::*;
 pub use hal::stm32::interrupt::*;
+pub use hal::stm32::Peripherals;
+pub use hal::stm32::Interrupt as interrupt;
 pub use hal::stm32::*;
 pub use hal::*;


### PR DESCRIPTION
japaric's Real-Time For The Masses framework expects board support crates to re-export their device's interrupt enum `Interrupt` as `interrupt`. Moreover, re-exportig `hal::stm32::Peripherals` makes it possible to specify this crate as target device in RTFM's `app` attribute like so:
```
use stm32f407g_disc as board;

#[app(device = board)]
```