### PR TITLE
Add LED abstraction similar to what exists in the f3 crate

### DIFF
--- a/examples/gpio_hal_blinky.rs
+++ b/examples/gpio_hal_blinky.rs
@@ -13,6 +13,8 @@ use board::hal::delay::Delay;
 use board::hal::prelude::*;
 use board::hal::stm32;
 
+use board::led::{Leds, LedColor};
+
 use cortex_m::peripheral::Peripherals;
 
 #[entry]
@@ -20,8 +22,8 @@ fn main() -> ! {
     if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
         let gpiod = p.GPIOD.split();
 
-        // (Re-)configure PD13 (orange LED) as output
-        let mut led = gpiod.pd13.into_push_pull_output();
+        // Initialize on-board LEDs
+        let mut leds = Leds::new(gpiod);
 
         // Constrain clock registers
         let mut rcc = p.RCC.constrain();
@@ -33,15 +35,30 @@ fn main() -> ! {
         let mut delay = Delay::new(cp.SYST, clocks);
 
         loop {
-            // Turn LED on
-            led.set_high();
+            // Turn LEDs on one after the other with 500ms delay between them
+            leds[LedColor::Orange].on();
+            delay.delay_ms(500_u16);
+            leds[LedColor::Red].on();
+            delay.delay_ms(500_u16);
+            leds[LedColor::Blue].on();
+            delay.delay_ms(500_u16);
+            leds[LedColor::Green].on();
+            delay.delay_ms(500_u16);
+
 
             // Delay twice for half a second due to limited timer resolution
             delay.delay_ms(500_u16);
             delay.delay_ms(500_u16);
 
-            // Turn LED off
-            led.set_low();
+            // Turn LEDs off one after the other with 500ms delay between them
+            leds[LedColor::Orange].off();
+            delay.delay_ms(500_u16);
+            leds[LedColor::Red].off();
+            delay.delay_ms(500_u16);
+            leds[LedColor::Blue].off();
+            delay.delay_ms(500_u16);
+            leds[LedColor::Green].off();
+            delay.delay_ms(500_u16);        
 
             // Delay twice for half a second due to limited timer resolution
             delay.delay_ms(500_u16);

--- a/examples/gpio_hal_busy_blinky.rs
+++ b/examples/gpio_hal_busy_blinky.rs
@@ -11,51 +11,49 @@ use cortex_m_rt::entry;
 
 use board::hal::prelude::*;
 use board::hal::stm32;
+use board::led::{Leds, LedColor};
 
 #[entry]
 fn main() -> ! {
     if let Some(p) = stm32::Peripherals::take() {
         let gpiod = p.GPIOD.split();
 
-        // (Re-)configure PD pins connected to the LEDs as output
-        let mut green = gpiod.pd12.into_push_pull_output();
-        let mut orange = gpiod.pd13.into_push_pull_output();
-        let mut red = gpiod.pd14.into_push_pull_output();
-        let mut blue = gpiod.pd15.into_push_pull_output();
+        // Initialize on-board LEDs
+        let mut leds = Leds::new(gpiod);
 
         // Endlessly blink the 4 LEDs in a circle, delaying by executing the state write many times
         // in a row
         loop {
-            for _ in 0..500_000 {
-                orange.set_high();
+            for _ in 0..10_000 {
+                leds[LedColor::Orange].on();
             }
 
-            for _ in 0..500_000 {
-                orange.set_low();
+            for _ in 0..10_000 {
+                leds[LedColor::Orange].off();
             }
 
-            for _ in 0..500_000 {
-                red.set_high();
+            for _ in 0..10_000 {
+                leds[LedColor::Red].on();
             }
 
-            for _ in 0..500_000 {
-                red.set_low();
+            for _ in 0..10_000 {
+                leds[LedColor::Red].off();
             }
 
-            for _ in 0..500_000 {
-                blue.set_high();
+            for _ in 0..10_000 {
+                leds[LedColor::Blue].on();
             }
 
-            for _ in 0..500_000 {
-                blue.set_low();
+            for _ in 0..10_000 {
+                leds[LedColor::Blue].off();
             }
 
-            for _ in 0..500_000 {
-                green.set_high();
+            for _ in 0..10_000 {
+                leds[LedColor::Green].on();
             }
 
-            for _ in 0..500_000 {
-                green.set_low();
+            for _ in 0..10_000 {
+                leds[LedColor::Green].off();
             }
         }
     }

--- a/src/led.rs
+++ b/src/led.rs
@@ -19,10 +19,10 @@ pub type LD6 = PD14<Output<PushPull>>;
 
 /// User LED colors
 pub enum LedColor {
-	/// Orange LED / LD3
-	Orange,
 	/// Green LED / LD4
 	Green,
+	/// Orange LED / LD3
+	Orange,
 	/// Red LED / LD5
 	Red,
 	/// Blue LED / LD6

--- a/src/led.rs
+++ b/src/led.rs
@@ -17,16 +17,16 @@ pub type LD5 = PD15<Output<PushPull>>;
 /// Bottom LED (blue)
 pub type LD6 = PD14<Output<PushPull>>;
 
-/// Positons of the user LEDs.
-pub enum Position {
-	/// Top / LD3
-	Top,
-	/// Left / LD4
-	Left,
-	/// Right / LD5
-	Right,
-	/// Bottom / LD6
-	Bottom,
+/// User LED colors
+pub enum LedColor {
+	/// Orange LED / LD3
+	Orange,
+	/// Green LED / LD4
+	Green,
+	/// Red LED / LD5
+	Red,
+	/// Blue LED / LD6
+	Blue,
 }
 
 // Array of the on-board user LEDs
@@ -74,11 +74,11 @@ impl core::ops::Index<usize> for Leds {
 	}
 }
 
-impl core::ops::Index<Position> for Leds {
+impl core::ops::Index<LedColor> for Leds {
 	type Output = Led;
 
-	fn index(&self, pos: Position) -> &Led {
-		&self.leds[pos as usize]
+	fn index(&self, c: LedColor) -> &Led {
+		&self.leds[c as usize]
 	}
 }
 
@@ -88,9 +88,9 @@ impl core::ops::IndexMut<usize> for Leds {
 	}
 }
 
-impl core::ops::IndexMut<Position> for Leds {
-	fn index_mut(&mut self, pos: Position) -> &mut Led {
-		&mut self.leds[pos as usize]
+impl core::ops::IndexMut<LedColor> for Leds {
+	fn index_mut(&mut self, c: LedColor) -> &mut Led {
+		&mut self.leds[c as usize]
 	}
 }
 

--- a/src/led.rs
+++ b/src/led.rs
@@ -35,7 +35,7 @@ pub struct Leds {
 }
 
 impl Leds {
-	pub fn new(mut gpiod: gpiod::Parts) -> Self {
+	pub fn new(gpiod: gpiod::Parts) -> Self {
 		let top = gpiod.pd12.into_push_pull_output();
 		let left = gpiod.pd13.into_push_pull_output();
 		let right = gpiod.pd14.into_push_pull_output();

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,0 +1,137 @@
+//! On-board user LEDs
+
+use hal::prelude::*;
+
+use hal::gpio::gpiod::{self, PD, PD12, PD13, PD14, PD15};
+use hal::gpio::{Output, PushPull};
+
+/// Top LED (orange)
+pub type LD3 = PD12<Output<PushPull>>;
+
+/// Left LED (green)
+pub type LD4 = PD13<Output<PushPull>>;
+
+/// Right LED (red)
+pub type LD5 = PD15<Output<PushPull>>;
+
+/// Bottom LED (blue)
+pub type LD6 = PD14<Output<PushPull>>;
+
+/// Positons of the user LEDs.
+pub enum Position {
+	/// Top / LD3
+	Top,
+	/// Left / LD4
+	Left,
+	/// Right / LD5
+	Right,
+	/// Bottom / LD6
+	Bottom,
+}
+
+// Array of the on-board user LEDs
+pub struct Leds {
+	leds: [Led; 4],
+}
+
+impl Leds {
+	pub fn new(mut gpiod: gpiod::Parts) -> Self {
+		let top = gpiod.pd12.into_push_pull_output();
+		let left = gpiod.pd13.into_push_pull_output();
+		let right = gpiod.pd14.into_push_pull_output();
+		let bottom = gpiod.pd15.into_push_pull_output();
+
+		Leds {
+			leds : [
+				top.into(),
+				left.into(),
+				right.into(),
+				bottom.into(),
+			],
+		}
+	}
+}
+
+impl core::ops::Deref for Leds {
+	type Target = [Led];
+
+	fn deref(&self) -> &[Led] {
+		&self.leds
+	}
+}
+
+impl core::ops::DerefMut for Leds {
+	fn deref_mut(&mut self) -> &mut [Led] {
+		&mut self.leds
+	}
+}
+
+impl core::ops::Index<usize> for Leds {
+	type Output = Led;
+
+	fn index(&self, i: usize) -> &Led {
+		&self.leds[i]
+	}
+}
+
+impl core::ops::Index<Position> for Leds {
+	type Output = Led;
+
+	fn index(&self, pos: Position) -> &Led {
+		&self.leds[pos as usize]
+	}
+}
+
+impl core::ops::IndexMut<usize> for Leds {
+	fn index_mut(&mut self, i: usize) -> &mut Led {
+		&mut self.leds[i]
+	}
+}
+
+impl core::ops::IndexMut<Position> for Leds {
+	fn index_mut(&mut self, pos: Position) -> &mut Led {
+		&mut self.leds[pos as usize]
+	}
+}
+
+/// One of the on-board user LEDs
+pub struct Led {
+	pin: PD<Output<PushPull>>,
+}
+
+macro_rules! ctor {
+	($($ldx:ident),+) => {
+		$(
+			impl Into<Led> for $ldx {
+				fn into(self) -> Led {
+					Led {
+						pin: self.downgrade(),
+					}
+				}
+			}
+		)+
+	}
+}
+
+ctor!(LD3, LD4, LD5, LD6);
+
+impl Led {
+	/// Turns the LED off
+	pub fn off(&mut self) {
+		self.pin.set_low();
+	}
+
+	/// Turns the LED on
+	pub fn on(&mut self) {
+		self.pin.set_high();
+	}
+
+	/// Toggles the LED
+	pub fn toggle(&mut self) {
+		if self.pin.is_low() {
+			self.pin.set_high();
+		} else {
+			self.pin.set_low();
+		}
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,5 @@ pub use hal::stm32::Peripherals;
 pub use hal::stm32::Interrupt as interrupt;
 pub use hal::stm32::*;
 pub use hal::*;
+
+pub mod led;


### PR DESCRIPTION
I adapted the LED abstraction from the f3 crate for the 4 on-board LEDs  of the stm32f4discovery. Tested on hardware.